### PR TITLE
Add hacks made at royal oak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ packer_*
 *.swp
 *.log
 #
-testbuild
+images
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ vmb:
 
 clean:
 	@rm -f packer-builder-openbsd-vmm
+	@rm -fr images
+	@rm -fr packer_cache
 
 uninstall: clean
 	@rm -f ~/.packer.d/plugins/packer-builder-openbsd-vmm
-

--- a/builder/openbsd-vmm/config.go
+++ b/builder/openbsd-vmm/config.go
@@ -12,16 +12,15 @@ import (
 type Config struct {
 	common.PackerConfig    `mapstructure:",squash"`
 	common.HTTPConfig      `mapstructure:",squash"`
-	common.ISOConfig       `mapstructure:",squash"`
 	bootcommand.BootConfig `mapstructure:",squash"`
 	Comm                   communicator.Config `mapstructure:",squash"`
 	RawBootWait            string              `mapstructure:"boot_wait"`
 	bootWait               time.Duration       ``
 
 	VMName     string `mapstructure:"vm_name"`
-	Console    bool   `mapstructure:"console"`     // attach a console (to debug)
-	BootImage  string `mapstructure:"boot_image"`  //installNN.fs
-	ImageName  string `mapstructure:"image_name"`  // artifact from build
+	Console    bool   `mapstructure:"console"` // attach a console (to debug)
+	Bios       string `mapstructure:"bios"`    // /bsd.rd, /etc/firmware/vmm-bios
+	IsoImage   string `mapstructure:"iso_image"`
 	DiskSize   string `mapstructure:"disk_size"`   // as vmctl -s
 	DiskFormat string `mapstructure:"disk_format"` // as vmctl create
 	RAMSize    string `mapstructure:"ram_size"`    // as vmctl -m

--- a/builder/openbsd-vmm/driver.go
+++ b/builder/openbsd-vmm/driver.go
@@ -18,6 +18,7 @@ type Driver interface {
 	bootcommand.BCDriver
 	VmctlCmd(bool, ...string) error
 	Start(...string) error
+	Stop(string) error
 	GetTapIPAddress(string) (string, error)
 	//Flush() error
 }

--- a/builder/openbsd-vmm/step_create_disks.go
+++ b/builder/openbsd-vmm/step_create_disks.go
@@ -11,7 +11,7 @@ import (
 
 type stepCreateDisks struct {
 	outputPath string
-	image      string
+	name       string
 	format     string
 	size       string
 }
@@ -20,7 +20,7 @@ func (step *stepCreateDisks) Run(ctx context.Context, state multistep.StateBag) 
 	driver := state.Get("driver").(Driver)
 	var usedoas bool = false
 	ui := state.Get("ui").(packer.Ui)
-	path := filepath.Join(step.outputPath, step.image)
+	path := filepath.Join(step.outputPath, step.name)
 
 	command := []string{
 		"create",

--- a/examples/openbsd.json
+++ b/examples/openbsd.json
@@ -2,23 +2,20 @@
   "builders": [
     {
       "type": "openbsd-vmm",
-      "vm_name": "VMnameinput",
       "name": "packer-obsd64-vmm-amd64",
+      "vm_name": "myvm",
       "disk_size": "1500M",
       "disk_format": "raw",
-      "output_directory": "tempbuilds",
-      "image_name": "OpenBSD-VMM-image",
+      "output_directory": "images",
       "http_directory": "./docroot",
-      "boot_image": "/bsd.rd",
+      "iso_image": "~/Downloads/install65.iso",
+      "bios": "/bsd.rd",
       "boot_wait": "5s",
       "boot_command": [
         "A<enter>",
         "http://{{ .HTTPIP }}:{{ .HTTPPort }}/packer-auto_install.conf<enter>"
       ],
-      "ssh_username": "root",
-      "iso_url": "file:///Users/pbuehler/Software/ISOs/install59.iso",
-      "iso_checksum": "685262fc665425c61a2952b2820389a2d331ac5558217080e6d564d2ce88eecb",
-      "iso_checksum_type": "sha256"
+      "ssh_username": "root"
     }
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.12
 
 require (
 	github.com/hashicorp/packer v1.4.0
+	github.com/mitchellh/go-homedir v1.0.0
 	github.com/pkg/errors v0.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/creack/goselect v0.0.0-20180210034346-528c74964609/go.mod h1:gHrIcH/9UZDn2qgeTUeW5K9eZsVYCH6/60J/FHysWyE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denverdino/aliyungo v0.0.0-20190220033614-36e2ae938978/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -71,6 +72,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -215,6 +217,7 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v0.0.0-20160118190721-e84cc8c755ca h1:k8gsErq3rkcbAyCnpOycQsbw88NjCHk7L3KfBZKhQDQ=
 github.com/pkg/sftp v0.0.0-20160118190721-e84cc8c755ca/go.mod h1:NxmoDg/QLVWluQDUYG7XBZTLUpKeFa8e3aMf1BfjyHk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/profitbricks/profitbricks-sdk-go v4.0.2+incompatible/go.mod h1:T3/WrziK7fYH3C8ilAFAHe99R452/IzIG3YYkqaOFeQ=
@@ -263,6 +266,7 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tencentcloud/tencentcloud-sdk-go v0.0.0-20181220135002-f1744d40d346/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=


### PR DESCRIPTION
- Use `images` instead of `tempbuild`
- Add `iso` option, expand home dir `~`
- Add error handling / checking
- Remove stale ISO config
- Use builder name for name of the artifact image
- Don't bail out if output directory is present
- Bail out if image is already present
- Add `Stop()` for cleaning up image after create
- Make iso optional