### PR TITLE
Add qcow2 capability

### DIFF
--- a/builder/openbsd-vmm/config.go
+++ b/builder/openbsd-vmm/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	IsoImage   string `mapstructure:"iso_image"`
 	DiskSize   string `mapstructure:"disk_size"`   // as vmctl -s
 	DiskFormat string `mapstructure:"disk_format"` // as vmctl create
+	DiskBase   string `mapstructure:"disk_base"`   // for qcow2 only
 	RAMSize    string `mapstructure:"ram_size"`    // as vmctl -m
 	// not everybody lives in autoconf/DHCP; populate for hostname.vi0
 	Inet4   string `mapstructure:"inet4"`       // hostname.if 'inet'

--- a/builder/openbsd-vmm/step_create_disks.go
+++ b/builder/openbsd-vmm/step_create_disks.go
@@ -14,6 +14,7 @@ type stepCreateDisks struct {
 	name       string
 	format     string
 	size       string
+	baseImage  string
 }
 
 func (step *stepCreateDisks) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -24,11 +25,17 @@ func (step *stepCreateDisks) Run(ctx context.Context, state multistep.StateBag) 
 
 	command := []string{
 		"create",
-		//step.format + ":" + path,
-		path,
+		step.format + ":" + path,
 		"-s",
 		step.size,
 	}
+
+	if step.baseImage != "" {
+		command = append(command,
+			"-b",
+			step.baseImage)
+	}
+
 	ui.Say("Creating disk images...")
 	if err := driver.VmctlCmd(usedoas, command...); err != nil {
 		err := fmt.Errorf("Error creating disk image: %s", err)
@@ -38,9 +45,7 @@ func (step *stepCreateDisks) Run(ctx context.Context, state multistep.StateBag) 
 	}
 
 	state.Put("disk_image", path)
-
 	return multistep.ActionContinue
 }
 
-func (step *stepCreateDisks) Cleanup(state multistep.StateBag) {
-}
+func (step *stepCreateDisks) Cleanup(state multistep.StateBag) {}

--- a/examples/openbsd.json
+++ b/examples/openbsd.json
@@ -5,7 +5,7 @@
       "name": "packer-obsd64-vmm-amd64",
       "vm_name": "myvm",
       "disk_size": "1500M",
-      "disk_format": "raw",
+      "disk_format": "qcow2",
       "output_directory": "images",
       "http_directory": "./docroot",
       "iso_image": "~/Downloads/install65.iso",


### PR DESCRIPTION
Adds `qcow2` capabilities, and allows creating a VM from an existing
base `qcow2` disk image.