### PR TITLE
Eliminate doas(1) by using VM instances; sync with vm.conf(5) syntax; cleanup

### DIFF
--- a/builder/openbsd-vmm/config.go
+++ b/builder/openbsd-vmm/config.go
@@ -17,14 +17,15 @@ type Config struct {
 	RawBootWait            string              `mapstructure:"boot_wait"`
 	bootWait               time.Duration       ``
 
-	VMName     string `mapstructure:"vm_name"`
+	VMName     string `mapstructure:"vm_name" required:"true"`
+	VMTemplate string `mapstructure:"vm_template" required:"true"`
 	Console    bool   `mapstructure:"console"` // attach a console (to debug)
-	Bios       string `mapstructure:"bios"`    // /bsd.rd, /etc/firmware/vmm-bios
-	IsoImage   string `mapstructure:"iso_image"`
+	Boot       string `mapstructure:"boot"`    // /bsd.rd, /etc/firmware/vmm-bios
+	CdRom      string `mapstructure:"cdrom"`
 	DiskSize   string `mapstructure:"disk_size"`   // as vmctl -s
 	DiskFormat string `mapstructure:"disk_format"` // as vmctl create
 	DiskBase   string `mapstructure:"disk_base"`   // for qcow2 only
-	RAMSize    string `mapstructure:"ram_size"`    // as vmctl -m
+	MemorySize string `mapstructure:"memory"`      // as vmctl -m
 	// not everybody lives in autoconf/DHCP; populate for hostname.vi0
 	Inet4   string `mapstructure:"inet4"`       // hostname.if 'inet'
 	Inet4GW string `mapstructure:"inet4gw"`     // mygate 'inet'
@@ -32,6 +33,7 @@ type Config struct {
 	Inet6GW string `mapstructure:"inet6gw"`     // mygate 'inet6'
 	DNS     string `mapstructure:"nameservers"` // resolv.conf, comma-separated
 
+	LogDir   string `mapstructure:"log_directory"`
 	OutDir   string `mapstructure:"output_directory"`
 	UserData string `mapstructure:"user_data"`
 

--- a/builder/openbsd-vmm/config.hcl2spec.go
+++ b/builder/openbsd-vmm/config.hcl2spec.go
@@ -62,19 +62,21 @@ type FlatConfig struct {
 	WinRMUseSSL               *bool             `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl"`
 	WinRMInsecure             *bool             `mapstructure:"winrm_insecure" cty:"winrm_insecure"`
 	WinRMUseNTLM              *bool             `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm"`
-	VMName                    *string           `mapstructure:"vm_name" cty:"vm_name"`
+	VMName                    *string           `mapstructure:"vm_name" required:"true" cty:"vm_name"`
+	VMTemplate                *string           `mapstructure:"vm_template" required:"true" cty:"vm_template"`
 	Console                   *bool             `mapstructure:"console" cty:"console"`
-	Bios                      *string           `mapstructure:"bios" cty:"bios"`
-	IsoImage                  *string           `mapstructure:"iso_image" cty:"iso_image"`
+	Boot                      *string           `mapstructure:"boot" cty:"boot"`
+	CdRom                     *string           `mapstructure:"cdrom" cty:"cdrom"`
 	DiskSize                  *string           `mapstructure:"disk_size" cty:"disk_size"`
 	DiskFormat                *string           `mapstructure:"disk_format" cty:"disk_format"`
 	DiskBase                  *string           `mapstructure:"disk_base" cty:"disk_base"`
-	RAMSize                   *string           `mapstructure:"ram_size" cty:"ram_size"`
+	MemorySize                *string           `mapstructure:"memory" cty:"memory"`
 	Inet4                     *string           `mapstructure:"inet4" cty:"inet4"`
 	Inet4GW                   *string           `mapstructure:"inet4gw" cty:"inet4gw"`
 	Inet6                     *string           `mapstructure:"inet6" cty:"inet6"`
 	Inet6GW                   *string           `mapstructure:"inet6gw" cty:"inet6gw"`
 	DNS                       *string           `mapstructure:"nameservers" cty:"nameservers"`
+	LogDir                    *string           `mapstructure:"log_directory" cty:"log_directory"`
 	OutDir                    *string           `mapstructure:"output_directory" cty:"output_directory"`
 	UserData                  *string           `mapstructure:"user_data" cty:"user_data"`
 }
@@ -145,18 +147,20 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_insecure":               &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":               &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
+		"vm_template":                  &hcldec.AttrSpec{Name: "vm_template", Type: cty.String, Required: false},
 		"console":                      &hcldec.AttrSpec{Name: "console", Type: cty.Bool, Required: false},
-		"bios":                         &hcldec.AttrSpec{Name: "bios", Type: cty.String, Required: false},
-		"iso_image":                    &hcldec.AttrSpec{Name: "iso_image", Type: cty.String, Required: false},
+		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
+		"cdrom":                        &hcldec.AttrSpec{Name: "cdrom", Type: cty.String, Required: false},
 		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.String, Required: false},
 		"disk_format":                  &hcldec.AttrSpec{Name: "disk_format", Type: cty.String, Required: false},
 		"disk_base":                    &hcldec.AttrSpec{Name: "disk_base", Type: cty.String, Required: false},
-		"ram_size":                     &hcldec.AttrSpec{Name: "ram_size", Type: cty.String, Required: false},
+		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.String, Required: false},
 		"inet4":                        &hcldec.AttrSpec{Name: "inet4", Type: cty.String, Required: false},
 		"inet4gw":                      &hcldec.AttrSpec{Name: "inet4gw", Type: cty.String, Required: false},
 		"inet6":                        &hcldec.AttrSpec{Name: "inet6", Type: cty.String, Required: false},
 		"inet6gw":                      &hcldec.AttrSpec{Name: "inet6gw", Type: cty.String, Required: false},
 		"nameservers":                  &hcldec.AttrSpec{Name: "nameservers", Type: cty.String, Required: false},
+		"log_directory":                &hcldec.AttrSpec{Name: "log_directory", Type: cty.String, Required: false},
 		"output_directory":             &hcldec.AttrSpec{Name: "output_directory", Type: cty.String, Required: false},
 		"user_data":                    &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},
 	}

--- a/builder/openbsd-vmm/driver.go
+++ b/builder/openbsd-vmm/driver.go
@@ -18,7 +18,7 @@ import (
 
 type Driver interface {
 	bootcommand.BCDriver
-	VmctlCmd(bool, ...string) error
+	VmctlCmd(args ...string) error
 	Start(...string) error
 	Stop(string) error
 	GetTapIPAddress(string) (string, error)
@@ -27,7 +27,6 @@ type Driver interface {
 }
 
 type vmmDriver struct {
-	doas    string
 	vmctl   string
 	logfile string
 	tty     io.WriteCloser
@@ -52,20 +51,12 @@ func (d *vmmDriver) GetVMId(name string) string {
 	return resultarr[0][1]
 }
 
-func (d *vmmDriver) VmctlCmd(usedoas bool, args ...string) error {
+func (d *vmmDriver) VmctlCmd(args ...string) error {
 	var stdout, stderr bytes.Buffer
 	var cmd *exec.Cmd
-	if usedoas {
-		args = append([]string{d.vmctl}, args...)
-		//args = append([]string{"ktrace"}, args...)
-		log.Printf("Executing doas: %#v", args)
-		cmd = exec.Command(d.doas, args...)
-	} else {
-		//args = append([]string{"vmctl"}, args...)
-		//cmd = exec.Command("ktrace", args...)
-		log.Printf("Executing vmctl: %#v", args)
-		cmd = exec.Command(d.vmctl, args...)
-	}
+	//cmd = exec.Command("ktrace", args...)
+	log.Printf("Executing vmctl: %#v", args)
+	cmd = exec.Command(d.vmctl, args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
@@ -88,10 +79,9 @@ func (d *vmmDriver) Start(args ...string) error {
 		return err
 	}
 
-	args = append([]string{d.vmctl}, args...)
-	//d.ui.Message("Executing " + d.doas + " " + strings.Join(args, " "))
+	//d.ui.Message("Executing vmctl:" + strings.Join(args, " "))
 
-	cmd := exec.Command(d.doas, args...)
+	cmd := exec.Command(d.vmctl, args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -121,7 +111,7 @@ func (d *vmmDriver) Start(args ...string) error {
 }
 
 func (d *vmmDriver) Stop(name string) error {
-	cmd := exec.Command(d.doas, d.vmctl, "stop", name)
+	cmd := exec.Command(d.vmctl, "stop", name)
 	//err := cmd.Run()
 	cmd.Run()
 	return nil

--- a/builder/openbsd-vmm/step_create_disks.go
+++ b/builder/openbsd-vmm/step_create_disks.go
@@ -19,9 +19,8 @@ type stepCreateDisks struct {
 
 func (step *stepCreateDisks) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	driver := state.Get("driver").(Driver)
-	var usedoas bool = false
 	ui := state.Get("ui").(packer.Ui)
-	path := filepath.Join(step.outputPath, step.name)
+	path := filepath.Join(step.outputPath, step.name + "." + step.format)
 
 	// >= 6.6 format : vmctl [-v] create [-b base | -i disk] [-s size] disk
 	command := []string{
@@ -37,10 +36,10 @@ func (step *stepCreateDisks) Run(ctx context.Context, state multistep.StateBag) 
 	}
 
 	command = append(command,
-		step.format+":"+path)
+		step.format + ":" + path)
 
 	ui.Say("Creating disk images...")
-	if err := driver.VmctlCmd(usedoas, command...); err != nil {
+	if err := driver.VmctlCmd(command...); err != nil {
 		err := fmt.Errorf("Error creating disk image: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())

--- a/builder/openbsd-vmm/step_launch_vm.go
+++ b/builder/openbsd-vmm/step_launch_vm.go
@@ -9,10 +9,11 @@ import (
 )
 
 type stepLaunchVM struct {
-	name   string
-	mem    string
-	kernel string
-	iso    string
+	name     string
+	mem      string
+	kernel   string
+	iso      string
+	template string
 }
 
 func (step *stepLaunchVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -30,12 +31,24 @@ func (step *stepLaunchVM) Run(ctx context.Context, state multistep.StateBag) mul
 		"net",
 		"-i",
 		"1",
-		"-m",
-		step.mem,
-		"-b",
-		step.kernel,
 		"-d",
-		diskImage}
+		diskImage,
+		"-t",
+		step.template}
+
+	if step.mem != "" {
+		command = append(command,
+			"-m",
+			step.mem,
+		)
+	}
+
+	if step.kernel != "" {
+		command = append(command,
+			"-b",
+			step.kernel,
+		)
+	}
 
 	if step.iso != "" {
 		command = append(command,

--- a/builder/openbsd-vmm/step_outdir.go
+++ b/builder/openbsd-vmm/step_outdir.go
@@ -13,6 +13,7 @@ import (
 type stepOutDir struct {
 	outputPath string
 	name       string
+	format     string
 	force      bool
 }
 
@@ -32,7 +33,7 @@ func (step *stepOutDir) Run(ctx context.Context, state multistep.StateBag) multi
 
 	// Check if output image exists
 	if _, err := os.Stat(
-		filepath.Join(step.outputPath, step.name)); !os.IsNotExist(err) {
+		filepath.Join(step.outputPath, step.name, ".", step.format)); !os.IsNotExist(err) {
 		// If the build isn't forced, error out here.
 		if !step.force {
 			state.Put("error", fmt.Errorf("image already exists: %s", step.name))

--- a/examples/openbsd.json
+++ b/examples/openbsd.json
@@ -11,7 +11,8 @@
       "output_directory": "/home/packer_user/.local/share/packer",
       "boot_wait": "15s",
       "boot_command": [
-	"http://192.168.255.1/autoinstall/packer-install.conf<enter>"
+	"http://{{ .HTTPIP }}:{{ .HTTPPort }}/packer-auto_install-iso.conf<enter>",
+	"I<enter>"
       ],
       "ssh_username": "root"
     }

--- a/examples/openbsd.json
+++ b/examples/openbsd.json
@@ -2,18 +2,16 @@
   "builders": [
     {
       "type": "openbsd-vmm",
-      "name": "packer-obsd64-vmm-amd64",
-      "vm_name": "myvm",
-      "disk_size": "1500M",
+      "vm_name": "openbsd",
+      "vm_template": "generic",
       "disk_format": "qcow2",
-      "output_directory": "images",
-      "http_directory": "./docroot",
-      "iso_image": "~/Downloads/install65.iso",
-      "bios": "/bsd.rd",
+      "disk_size": "20G",
+      "boot": "/var/www/htdocs/openbsd/snapshots/amd64/bsd.rd",
+      "log_directory": "/home/packer_user/.log/packer",
+      "output_directory": "/home/packer_user/.local/share/packer",
       "boot_wait": "15s",
       "boot_command": [
-        "http://{{ .HTTPIP }}:{{ .HTTPPort }}/packer-auto_install-iso.conf<enter>",
-        "I<enter>"
+	"http://192.168.255.1/autoinstall/packer-install.conf<enter>"
       ],
       "ssh_username": "root"
     }

--- a/examples/vm.conf.sample
+++ b/examples/vm.conf.sample
@@ -1,0 +1,22 @@
+local prefix 192.168.255.128/28
+sets="/var/www/htdocs/openbsd/snapshots/amd64/"
+iso="install66.iso"
+
+switch "local" {
+	interface bridge0
+}
+
+vm generic {
+	disable
+	owner packer_user
+	disk /dev/null
+	cdrom $sets $iso
+	allow instance {
+		boot,
+		cdrom,
+		disk,
+		instance,
+		interface,
+		memory
+	}
+}


### PR DESCRIPTION
1. Eliminate doas(1) by using VM instances. This also allows to use access control features provided by vmd(8).

2. Add new and rename some existing configuration items to be more in sync with what is used in vm.conf(5), otherwise we have to mind-map it, like "bios" in json = "boot" in vm.conf:
```
    vm_name             - set to "required"
    vm_template         - new, set to "required"
    bios                - rename to "boot"
    iso_image           - rename to "cdrom"
    ram_size            - rename to "memory"
    log_directory       - new, to be able to set arbitrary directory for logs
```                             

3. Remove some sanity checks and hardcoded defaults like use "packer-" for "vm_name" if former isn't provided, set memory to 512m if not provided wich access control on what can be changed by template user.

4. Add vm.conf(5) example, update existing json examples.