### PR TITLE
Enable provisioning

### DIFF
--- a/builder/openbsd-vmm/config.go
+++ b/builder/openbsd-vmm/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/common/bootcommand"
+	"github.com/hashicorp/packer/common/shutdowncommand"
 	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/template/interpolate"
 )
@@ -13,19 +14,21 @@ type Config struct {
 	common.PackerConfig    `mapstructure:",squash"`
 	common.HTTPConfig      `mapstructure:",squash"`
 	bootcommand.BootConfig `mapstructure:",squash"`
+	shutdowncommand.ShutdownConfig `mapstructure:",squash"`
 	Comm                   communicator.Config `mapstructure:",squash"`
 	RawBootWait            string              `mapstructure:"boot_wait"`
 	bootWait               time.Duration       ``
 
 	VMName     string `mapstructure:"vm_name" required:"true"`
-	VMTemplate string `mapstructure:"vm_template" required:"true"`
-	Console    bool   `mapstructure:"console"` // attach a console (to debug)
-	Boot       string `mapstructure:"boot"`    // /bsd.rd, /etc/firmware/vmm-bios
-	CdRom      string `mapstructure:"cdrom"`
-	DiskSize   string `mapstructure:"disk_size"`   // as vmctl -s
-	DiskFormat string `mapstructure:"disk_format"` // as vmctl create
-	DiskBase   string `mapstructure:"disk_base"`   // for qcow2 only
-	MemorySize string `mapstructure:"memory"`      // as vmctl -m
+	VMTemplate string `mapstructure:"vm_template" required:"true"`  // vmctl -t
+	Console    bool   `mapstructure:"console"`     // vmctl -c
+	BootDevice string `mapstructure:"boot_device"` // vmctl -B
+	Boot       string `mapstructure:"boot"`        // vmctl -b
+	CdRom      string `mapstructure:"cdrom"`       // vmctl -r
+	DiskFormat string `mapstructure:"disk_format"` // vmctl create
+	DiskBase   string `mapstructure:"disk_base"`   // vmctl create -b
+	DiskSize   string `mapstructure:"disk_size"`   // vmctl create -s
+	MemorySize string `mapstructure:"memory"`      // vmctl -m
 	// not everybody lives in autoconf/DHCP; populate for hostname.vi0
 	Inet4   string `mapstructure:"inet4"`       // hostname.if 'inet'
 	Inet4GW string `mapstructure:"inet4gw"`     // mygate 'inet'

--- a/builder/openbsd-vmm/config.hcl2spec.go
+++ b/builder/openbsd-vmm/config.hcl2spec.go
@@ -22,6 +22,8 @@ type FlatConfig struct {
 	BootGroupInterval         *string           `mapstructure:"boot_keygroup_interval" cty:"boot_keygroup_interval"`
 	BootWait                  *string           `mapstructure:"boot_wait" cty:"boot_wait"`
 	BootCommand               []string          `mapstructure:"boot_command" cty:"boot_command"`
+	ShutdownCommand           *string           `mapstructure:"shutdown_command" required:"false" cty:"shutdown_command"`
+	ShutdownTimeout           *string           `mapstructure:"shutdown_timeout" required:"false" cty:"shutdown_timeout"`
 	Type                      *string           `mapstructure:"communicator" cty:"communicator"`
 	PauseBeforeConnect        *string           `mapstructure:"pause_before_connecting" cty:"pause_before_connecting"`
 	SSHHost                   *string           `mapstructure:"ssh_host" cty:"ssh_host"`
@@ -65,11 +67,12 @@ type FlatConfig struct {
 	VMName                    *string           `mapstructure:"vm_name" required:"true" cty:"vm_name"`
 	VMTemplate                *string           `mapstructure:"vm_template" required:"true" cty:"vm_template"`
 	Console                   *bool             `mapstructure:"console" cty:"console"`
+	BootDevice                *string           `mapstructure:"boot_device" cty:"boot_device"`
 	Boot                      *string           `mapstructure:"boot" cty:"boot"`
 	CdRom                     *string           `mapstructure:"cdrom" cty:"cdrom"`
-	DiskSize                  *string           `mapstructure:"disk_size" cty:"disk_size"`
 	DiskFormat                *string           `mapstructure:"disk_format" cty:"disk_format"`
 	DiskBase                  *string           `mapstructure:"disk_base" cty:"disk_base"`
+	DiskSize                  *string           `mapstructure:"disk_size" cty:"disk_size"`
 	MemorySize                *string           `mapstructure:"memory" cty:"memory"`
 	Inet4                     *string           `mapstructure:"inet4" cty:"inet4"`
 	Inet4GW                   *string           `mapstructure:"inet4gw" cty:"inet4gw"`
@@ -106,6 +109,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_keygroup_interval":       &hcldec.AttrSpec{Name: "boot_keygroup_interval", Type: cty.String, Required: false},
 		"boot_wait":                    &hcldec.AttrSpec{Name: "boot_wait", Type: cty.String, Required: false},
 		"boot_command":                 &hcldec.AttrSpec{Name: "boot_command", Type: cty.List(cty.String), Required: false},
+		"shutdown_command":             &hcldec.AttrSpec{Name: "shutdown_command", Type: cty.String, Required: false},
+		"shutdown_timeout":             &hcldec.AttrSpec{Name: "shutdown_timeout", Type: cty.String, Required: false},
 		"communicator":                 &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":      &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                     &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},
@@ -149,11 +154,12 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"vm_template":                  &hcldec.AttrSpec{Name: "vm_template", Type: cty.String, Required: false},
 		"console":                      &hcldec.AttrSpec{Name: "console", Type: cty.Bool, Required: false},
+		"boot_device":                  &hcldec.AttrSpec{Name: "boot_device", Type: cty.String, Required: false},
 		"boot":                         &hcldec.AttrSpec{Name: "boot", Type: cty.String, Required: false},
 		"cdrom":                        &hcldec.AttrSpec{Name: "cdrom", Type: cty.String, Required: false},
-		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.String, Required: false},
 		"disk_format":                  &hcldec.AttrSpec{Name: "disk_format", Type: cty.String, Required: false},
 		"disk_base":                    &hcldec.AttrSpec{Name: "disk_base", Type: cty.String, Required: false},
+		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.String, Required: false},
 		"memory":                       &hcldec.AttrSpec{Name: "memory", Type: cty.String, Required: false},
 		"inet4":                        &hcldec.AttrSpec{Name: "inet4", Type: cty.String, Required: false},
 		"inet4gw":                      &hcldec.AttrSpec{Name: "inet4gw", Type: cty.String, Required: false},

--- a/builder/openbsd-vmm/driver.go
+++ b/builder/openbsd-vmm/driver.go
@@ -55,7 +55,8 @@ func (d *vmmDriver) VmctlCmd(args ...string) error {
 	var stdout, stderr bytes.Buffer
 	var cmd *exec.Cmd
 	//cmd = exec.Command("ktrace", args...)
-	log.Printf("Executing vmctl: %#v", args)
+	//log.Printf("Executing vmctl: %#v", args)
+	log.Printf("Executing vmctl: vmctl %s", strings.Join(args, " "))
 	cmd = exec.Command(d.vmctl, args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -73,13 +74,13 @@ func (d *vmmDriver) VmctlCmd(args ...string) error {
 
 // Start the VM and create a pipe to insert commands into the VM. (from packer-builder-vmm)
 func (d *vmmDriver) Start(args ...string) error {
-	//d.ui.Message("Logging console output to " + d.logfile)
-	logFile, err := os.Create(d.logfile)
+	logFile, err := os.OpenFile(d.logfile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
 
-	//d.ui.Message("Executing vmctl:" + strings.Join(args, " "))
+	//log.Printf("Executing vmctl: %#v", args)
+	log.Printf("Executing vmctl: vmctl %s", strings.Join(args, " "))
 
 	cmd := exec.Command(d.vmctl, args...)
 	stdout, err := cmd.StdoutPipe()

--- a/builder/openbsd-vmm/ssh.go
+++ b/builder/openbsd-vmm/ssh.go
@@ -1,0 +1,19 @@
+package openbsdvmm
+
+import (
+	"github.com/hashicorp/packer/helper/multistep"
+)
+
+func CommHost() func(multistep.StateBag) (string, error) {
+	return func(state multistep.StateBag) (string, error) {
+		config := state.Get("config").(*Config)
+		return config.Comm.SSHHost, nil
+	}
+}
+
+func SSHPort() func(multistep.StateBag) (int, error) {
+	return func(state multistep.StateBag) (int, error) {
+		config := state.Get("config").(*Config)
+		return config.Comm.SSHPort, nil
+	}
+}

--- a/builder/openbsd-vmm/step_bootcmd.go
+++ b/builder/openbsd-vmm/step_bootcmd.go
@@ -70,5 +70,4 @@ func (step *stepBootCmd) Run(ctx context.Context, state multistep.StateBag) mult
 	return multistep.ActionContinue
 }
 
-func (step *stepBootCmd) Cleanup(state multistep.StateBag) {
-}
+func (step *stepBootCmd) Cleanup(state multistep.StateBag) {}

--- a/builder/openbsd-vmm/step_launch_vm.go
+++ b/builder/openbsd-vmm/step_launch_vm.go
@@ -11,6 +11,7 @@ import (
 type stepLaunchVM struct {
 	name     string
 	mem      string
+	bootdev  string
 	kernel   string
 	iso      string
 	template string
@@ -27,8 +28,6 @@ func (step *stepLaunchVM) Run(ctx context.Context, state multistep.StateBag) mul
 		"start",
 		"-c",
 		"-L",
-		"-B",
-		"net",
 		"-i",
 		"1",
 		"-d",
@@ -40,6 +39,13 @@ func (step *stepLaunchVM) Run(ctx context.Context, state multistep.StateBag) mul
 		command = append(command,
 			"-m",
 			step.mem,
+		)
+	}
+
+	if step.bootdev != "" {
+		command = append(command,
+			"-B",
+			step.bootdev,
 		)
 	}
 
@@ -60,6 +66,7 @@ func (step *stepLaunchVM) Run(ctx context.Context, state multistep.StateBag) mul
 	command = append(command, step.name)
 
 	ui.Say("Bringing up VM...")
+	//ui.Message(fmt.Sprintf("Starting VM: vmctl %s", strings.Join(command, " ")))
 	if err := driver.Start(command...); err != nil {
 		err := fmt.Errorf("Error bringing VM up: %s", err)
 		state.Put("error", err)

--- a/builder/openbsd-vmm/step_shutdown.go
+++ b/builder/openbsd-vmm/step_shutdown.go
@@ -1,0 +1,80 @@
+package openbsdvmm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+)
+
+// This step shuts down the machine. It first attempts to do so gracefully,
+// but ultimately forcefully shuts it down if that fails.
+//
+// Uses:
+//   communicator packer.Communicator
+//   config *config
+//   driver Driver
+//   ui     packer.Ui
+//   vm_id  string
+//
+// Produces:
+//   <nothing>
+type stepShutdown struct {}
+
+func (step *stepShutdown) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	comm := state.Get("communicator").(packer.Communicator)
+	config := state.Get("config").(*Config)
+	driver := state.Get("driver").(Driver)
+	ui := state.Get("ui").(packer.Ui)
+	vmid := state.Get("vm_id").(string)
+
+	if config.ShutdownCommand != "" {
+		ui.Say("Gracefully halting virtual machine...")
+		log.Printf("Executing shutdown command: %s", config.ShutdownCommand)
+		cmd := &packer.RemoteCmd{Command: config.ShutdownCommand}
+		if err := cmd.RunWithUi(ctx, comm, ui); err != nil {
+			err := fmt.Errorf("Failed to send shutdown command: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+	} else {
+		ui.Say("Halting the virtual machine...")
+		if err := driver.Stop(vmid); err != nil {
+			err := fmt.Errorf("Error stopping VM: %s", err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	// Wait for the machine to actually shut down
+	log.Printf("Waiting max %s for shutdown to complete", config.ShutdownTimeout)
+	for {
+		halted := driver.GetVMId(vmid)
+
+		if halted == "VMAWOL" {
+			break
+		}
+
+		select {
+		case <-time.After(config.ShutdownTimeout):
+			err := errors.New("Timeout while waiting for machine to shutdown.")
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		default:
+			time.Sleep(5 * time.Second)
+		}
+	}
+
+	log.Println("VM shut down.")
+	return multistep.ActionContinue
+}
+
+func (step *stepShutdown) Cleanup(state multistep.StateBag) {}

--- a/examples/openbsd.pkr.hcl
+++ b/examples/openbsd.pkr.hcl
@@ -1,0 +1,47 @@
+variable "log_directory"        { default = "/home/packer_user/.log/packer" }
+variable "output_directory"     { default = "/home/packer_user/.local/share/packer" }
+variable "http_directory"       { default = "/home/packer_user/.config/packer/autoinstall" }
+variable "vm_template"          { default = "generic" }
+variable "disk_format"          { default = "qcow2" }
+variable "boot_device"          { default = "net" }
+variable "boot"                 { default = "/var/www/htdocs/openbsd/snapshots/amd64/bsd.rd" }
+variable "boot_wait"            { default = "15s" }
+variable "ssh_username"         { default = "packer_user" }
+variable "ssh_agent_auth"	{ default = "true" }
+variable "trusted_pkg_path"     { default = "http://192.168.255.1/pub/OpenBSD/%c/packages/%a/all" }
+variable "shutdown_command"     { default = "doas /sbin/halt -p" }
+
+source "openbsd-vmm" "openbsd" {
+    vm_name          = "openbsd"
+    vm_template      = "${var.vm_template}"
+    memory           = "2G"
+    disk_size        = "20G"
+    disk_format      = "${var.disk_format}"
+    boot_device      = "${var.boot_device}"
+    boot             = "${var.boot}"
+    boot_wait        = "${var.boot_wait}"
+    boot_command     = [
+        "http://{{ .HTTPIP }}:{{ .HTTPPort }}/openbsd.autoinstall<enter>",
+	"I<enter>"
+    ]
+    log_directory    = "${var.log_directory}"
+    output_directory = "${var.output_directory}"
+    http_directory   = "${var.http_directory}"
+    ssh_username     = "${var.ssh_username}"
+    # fixme: has to be auto-discovered
+    ssh_host         = "192.168.255.131"
+    ssh_agent_auth   = "${var.ssh_agent_auth}"
+    communicator     = "ssh"
+    shutdown_command = "${var.shutdown_command}"
+}
+
+build {
+    sources = [ "source.openbsd-vmm.openbsd" ]
+    #provisioner "breakpoint" { note = "Testing" }
+    provisioner "shell" {
+	inline = [
+	    "sleep 180",
+	    "env TRUSTED_PKG_PATH='${var.trusted_pkg_path}' doas pkg_add unzip"
+	]
+    }
+}


### PR DESCRIPTION
**Adds code required for provisioning installed VM.**

The process now is as follows:
1. VM boots using "_vmctl -B net -b bsd.rd..._" which **must** be specified in Packer's configuration file in case we want to autoinstall OpenBSD.
2. Upon successful install, VM shuts down ("_vmctl -B net_" feature).
3. VM is started once again with additional _stepLaunchVM_, this time without specific boot options (_-B/-b_), and goes through standard OpenBSD post-install process (ssh/iked keys creation, rc.firsttime, fw_update, etc.)
4. SSH connection to VM is established in _communicator.StepConnect_
5. Provisionning is done in _common.StepProvision_
6. _stepShutdown_ shuts down the VM

Also did some minor code cleanup/debug logging additions.

Todo:
- **VM IP discovery**
- **Find a solution for autoinstall _disklabel URL_ to make it work with Packer's HTTP server's dynamic IP/port**
- Improve UI messages/debug logging where necessary
- Code/examples for Linux guests
- Code cleanup/fmt