### PR TITLE
Return image path in VmmArtifact.Files

### DIFF
--- a/builder/openbsd-vmm/artifact.go
+++ b/builder/openbsd-vmm/artifact.go
@@ -6,17 +6,17 @@ import (
 )
 
 type VmmArtifact struct {
-	imageName []string
+	imageName string
 	imageDir  string
+	diskFormat string
 }
 
 func (*VmmArtifact) BuilderId() string {
 	return BuilderID
 }
 
-// who needs this?
 func (a *VmmArtifact) Files() []string {
-	return a.imageName
+	return []string{fmt.Sprintf("%s/%s.%s", a.imageDir, a.imageName, a.diskFormat)}
 }
 
 func (a *VmmArtifact) Id() string {

--- a/builder/openbsd-vmm/builder.go
+++ b/builder/openbsd-vmm/builder.go
@@ -147,7 +147,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 
 	artifact := &VmmArtifact{
 		imageDir:  b.config.OutDir,
-		imageName: []string{b.config.VMName},
+		imageName: b.config.VMName,
+		diskFormat: b.config.DiskFormat,
 	}
 	return artifact, nil
 }


### PR DESCRIPTION
When running the provisioner with post process steps, the post process actions are unable to find the image file. 
> => openbsd-vmm.openbsd (compress): Tarring out/disk.raw.tar.gz with pgzip
2021/11/01 22:39:49 packer-post-processor-compress plugin: error: Error creating tar: Unable to read file openbsd: open openbsd: no such file or directory

Return the file path to the image, so post processors can find the image file.